### PR TITLE
Alter flow of commission prices control panel

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -3627,6 +3627,29 @@ img + #detail-art-text {
 
 /* ------------------------------------ =submit, =profile, =commish, =compose -- */
 
+#commishprices-content {
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+}
+
+#commishprices-content .commish-row {
+    display: -webkit-flex;
+    display: flex;
+    margin-bottom: 10px;
+    flex-direction: column;  /* Overridden at larger sizes */
+    justify-content: space-around;
+}
+
+#commishprices-content .di-tags {
+    width: 100%
+}
+
+#commishprices-content .commish-row .half {
+    flex-basis: 48%;
+}
+
 #submit-form .options h3, #submit-form .tagging h3 {
     padding-bottom: 0.5em;
 }
@@ -3700,7 +3723,7 @@ img + #detail-art-text {
         clear: left;
     }
 
-    #edit-profile .settings, #commishprices-content .prices {
+    #edit-profile .settings {
         float: left;
         padding-left: 4%;
     }
@@ -3732,7 +3755,7 @@ img + #detail-art-text {
         padding-top: 2em;
     }
 
-    #edit-profile .social, #edit-profile .profile, #commishprices-content .info, #commishprices-content .di-tags {
+    #edit-profile .social, #edit-profile .profile {
         clear: both;
         width: 100%;
     }
@@ -3770,6 +3793,14 @@ img + #detail-art-text {
 }
 
 @media (min-width: 63em) {
+    #commishprices-content .commish-row {
+        flex-direction: row;
+    }
+
+    #commishprices-content .info {
+        flex: 0 0 60%;
+    }
+
     #submit-form.journal {
         max-width: 90em;
         margin: 0 auto;
@@ -3779,7 +3810,7 @@ img + #detail-art-text {
         width: 31%;
     }
 
-    #submit-form .info, #edit-profile .settings, #commishprices-content .prices {
+    #submit-form .info, #edit-profile .settings {
         clear: none;
         padding-left: 3.5%;
         margin-left: 0;
@@ -3789,7 +3820,7 @@ img + #detail-art-text {
         padding-left: 0;
     }
 
-    #submit-form .description, #submit-form .tagging, #submit-form .options, #edit-profile .profile, #commishprices-content .info {
+    #submit-form .description, #submit-form .tagging, #submit-form .options, #edit-profile .profile {
         margin-left: 65.5%;
         padding-left: 3.5%;
         clear: none;

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -3643,7 +3643,7 @@ img + #detail-art-text {
 }
 
 #commishprices-content .di-tags {
-    width: 100%
+    width: 100%;
 }
 
 #commishprices-content .commish-row .half {
@@ -3798,7 +3798,11 @@ img + #detail-art-text {
     }
 
     #commishprices-content .info {
-        flex: 0 0 60%;
+        flex: 0 0 55%;
+    }
+
+    #commishprices-content .commish-tags {
+        flex: 0 0 40%;
     }
 
     #submit-form.journal {

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -286,6 +286,18 @@
             fadebox.remove();
         });
 
+        // Commishinfo prices "autopopulate" dropdown
+
+        $('#commish-edit-select').on('change', function () {
+            var selectedID = $(this).val();
+            console.log(selectedID);
+            forEach(document.getElementsByClassName('select-priceid'), function (field) {
+                var myID = field.getAttribute('data-priceid');
+                var visible = selectedID == myID;
+                field.style.display = visible ? '' : 'none';
+            });
+        });
+
         // checkbox containers
         $('.input-checkbox input[type=checkbox]').each(function () {
             var that = this;

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -287,7 +287,6 @@
         });
 
         // Commishinfo prices "autopopulate" dropdown
-
         $('#commish-edit-select').on('change', function () {
             var selectedID = $(this).val();
             console.log(selectedID);

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -2,205 +2,229 @@ $def with (query, currencies, presets)
 $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
 
 <div id="commishprices-content" class="content form clear">
+  <div>
+    <h3>My General Commission Info</h3>
+    <p>Information about commissioning you and preferences for commission content</p>
+    <div class="commish-row">
+      <div class="info">
+        <form name="controleditcommishtext" action="/control/editcommishtext" method="post" class="clear">
+          $:{CSRF()}
 
-  <div class="column classes">
-    <h3>Create Classification</h3>
+          <label for="commish-info">Description</label>
+          <textarea class="markdown input last-input expanding" name="content" rows="8" id="commish-info">${query['content'] if query['content'] else ''}</textarea>
+          <br />
 
+          <button type="submit" class="button positive" style="float: right;">Save Description</button>
+        </form>
+      </div>
+      <div class="commish-tags">
+        <div class="di-tags">
+          <h3>Preferred Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
+          <p>
+            Use these tags to indicate subject matter you prefer to create, making it easier for
+            commissioners to find you.
+          </p>
+
+          <div class="tags open clear">
+            $if query['tags']:
+              $for tag in query['tags']:
+                <a href="/marketplace?q=${tag}">${tag}</a>
+            $else:
+              <p class="color-lighter">You have not defined any preferred tags.</p>
+          </div>
+
+          <h3 class="edit">Edit Tags</h3>
+          $:{RENDER("common/detail_tag_form.html", [query['userid'], "user", query['tags']])}
+
+        </div><!-- /di-tags -->
+        <div class="di-tags">
+          <h3>Opt-Out Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
+          <p>
+            You will not appear in results for commission searches containing these tags.
+          </p>
+
+          <div class="tags open clear">
+            $if query['opt_out']:
+              $for tag in query['opt_out']:
+                <a class="artist" href="/marketplace?q=${tag}">${tag}</a>
+            $else:
+              <p class="color-lighter">You have not defined any opt-out tags.</p>
+          </div>
+
+          <h3 class="edit">Edit Tags</h3>
+          $:{RENDER("common/detail_tag_form.html", [query['userid'], "optout", query['opt_out']])}
+        </div><!-- /di-tags2 -->
+      </div>
+    </div>
+  </div>
+  <hr />
+
+  <div>
+    <h3>New Commission Class</h3>
+    <p>Creates a new classification with a base price</p>
     <form name="controlcreatecommishclass" action="/control/createcommishclass" method="post" class="clear">
-      $:{CSRF()}
-      <label for="commishprices-addclass-preset">Class Presets</label>
-      <select class="input last-input" name="titlepreset" id="commishprices-addclass-preset">
-        <option value="" selected>Any/Other</option>
-        $for group_name, group_options in presets:
-          <optgroup label="${group_name}">
-            $for c in group_options:
-              <option value="${c}">${c}</option>
-          </optgroup>
-      </select>
-      <h4 class="or color-lighter"><i>&mdash; Or &mdash;</i></h4>
-      <label for="commishprices-addclass">Custom Class</label>
-      <input type="text" id="commishprices-addclass" class="input last-input" name="title"/>
-      <button type="submit" class="button last-input positive" style="float: right;">Create Class</button>
+      <div class="commish-row">
+        $:{CSRF()}
+        <div class="half">
+          <label for="commishprices-addclass">Class Name</label>
+          <input type="text" id="commishprices-addclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
+          <label for="commishprices-addclass-preset">Class Presets</label>
+          <select class="input last-input" name="titlepreset" id="commishprices-addclass-preset">
+            <option value="" selected>Any/Other</option>
+            $for group_name, group_options in presets:
+              <optgroup label="${group_name}">
+                $for c in group_options:
+                  <option value="${c}">${c}</option>
+              </optgroup>
+          </select>
+          <h4 class="or color-lighter"><i>&mdash; Or &mdash;</i></h4>
+          <label for="commishprices-addclass">Custom Class</label>
+          <input type="text" id="commishprices-addclass" class="input last-input" name="title"/>
+        </div>
+        <div class="half">
+          <label for="commishprices-addclass-price">Base Price Title</label>
+          <input type="text" class="input" name="title" id="commishprices-addclass-price" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
+
+          <label for="commish-min-amount">Minimum Amount</label>
+          <input type="text" class="input" name="min_amount" id="commish-min-amount" required="required" />
+
+          <label for="commish-max-amount">Maximum Amount (Optional)</label>
+          <input type="text" class="input" name="max_amount" id="commish-max-amount" />
+
+
+          <label for="commish-currency">Currency</label>
+          <select class="last-input" name="currency" id="commish-currency">
+            <option value="" selected="selected">United States Dollar</option>
+            <option value="e">European Union Euro</option>
+            <option value="p">British Pound Sterling</option>
+            <option value="y">Japanese Yen</option>
+            <option value="c">Canadian Dollar</option>
+            <option value="m">Mexican Peso</option>
+            <option value="u">Australian Dollar</option>
+          </select>
+          <button type="submit" class="button positive" style="float: right;">Create Class</button>
+        </div>
+      </div><!-- commish-row -->
     </form>
-
-    $if(query['class']):
-      <h3>Edit Classification</h3>
-      <form name="controleditcommishclass" action="/control/editcommishclass" method="post" class="clear">
+  </div>
+  <hr />
+  $if(query['class']) or True:
+    <div>
+      <h3>Add a Price to a Class</h3>
+      <p>Add a new base or add-on cost to a commission class</p>
+      <form name="controlcreatecommishprice" action="/control/createcommishprice" method="post" class="clear">
         $:{CSRF()}
-        <label for="commishprices-editclass">Class Title</label>
-        <select id="commishprices-editclass" class="input" name="classid">
-          <option value="">Select class:</option>
-          $for i in query['class']:
-            <option value="${i['classid']}">${i['title']}</option>
-        </select>
+        <div class="commish-row">
+          <div class="half">
+            <label for="commish-classselect">Classification</label>
+            <select class="input" name="classid" id="commish-classselect">
+              <option value="">Select class:</option>
+              $for i in query['class']:
+              <option value="${i['classid']}">${i['title']}</option>
+            </select>
+            <label for="commish-title">Price Title</label>
+            <input type="text" class="input" name="title" id="commish-title" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
+          </div>
+          <div class="half">
+            <label for="commish-min-amount">Minimum Amount</label>
+            <input type="number" step="any" class="input" name="min_amount" id="commish-min-amount" required="required" />
 
-        <label for="commishprices-renameclass">Rename To</label>
-        <input type="text" id="commishprices-renameclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
-        <button type="submit" class="button last-input positive" style="float: right;">Edit Class</button>
+            <label for="commish-max-amount">Maximum Amount (Optional)</label>
+            <input type="number" step="any" class="input" name="max_amount" id="commish-max-amount" />
+
+            <label for="commish-currency">Currency</label>
+            <select class="input" name="currency" id="commish-currency">
+              $for char, info in currencies.iteritems():
+              <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
+            </select>
+
+            <label for="commish-settings">Cost type</label>
+            <select class="input last-input" name="settings" id="commish-settings">
+              <option value="" selected="selected">This price is a base cost</option>
+              <option value="a">This price is an additional cost</option>
+            </select>
+          <button type="submit" class="button positive" style="float: right;">Create Price</button>
+        </div>
       </form>
-
-      <h3>Remove Classification</h3>
-      <form name="controlremovecommishclass" action="/control/removecommishclass" method="post" class="clear">
-        $:{CSRF()}
-        <label for="commishprices-removeclass">Class Title</label>
-        <select id="commishprices-removeclass" class="input last-input" name="classid">
-          <option value="">Select class:</option>
-          $for i in query['class']:
-            <option value="${i['classid']}">${i['title']}</option>
-        </select>
-        <button type="submit" class="button negative" style="float: right;">Remove Class</button>
-      </form>
-
-  </div><!-- /classes -->
-
-  <div class="column prices">
-    <h3>Create Price</h3>
-
-    <form name="controlcreatecommishprice" action="/control/createcommishprice" method="post" class="clear">
-      $:{CSRF()}
-
-      <label for="commish-title">Price Title</label>
-      <input type="text" class="input" name="title" id="commish-title" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
-
-      <label for="commish-classselect">Classification</label>
-      <select class="input" name="classid" id="commish-classselect">
-        <option value="">Select class:</option>
-        $for i in query['class']:
-          <option value="${i['classid']}">${i['title']}</option>
-      </select>
-
-      <label for="commish-min-amount">Minimum Amount</label>
-      <input type="number" step="any" class="input" name="min_amount" id="commish-min-amount" required="required" />
-
-      <label for="commish-max-amount">Maximum Amount (Optional)</label>
-      <input type="number" step="any" class="input" name="max_amount" id="commish-max-amount" />
-
-
-      <label for="commish-currency">Currency</label>
-      <select class="input" name="currency" id="commish-currency">
-        $for char, info in currencies.iteritems():
-          <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
-      </select>
-
-      <label for="commish-settings">Settings</label>
-      <select class="input last-input" name="settings" id="commish-settings">
-        <option value="" selected="selected">This price is a base cost</option>
-        <option value="a">This price is an additional cost</option>
-      </select>
-
-      <button type="submit" class="button positive" style="float: right;">Create Price</button>
-    </form>
-
-    $if(query['price']):
-      <h3>Edit Price</h3>
-      <form name="controleditcommishprice" action="/control/editcommishprice" method="post" class="clear">
-        $:{CSRF()}
-
-        <label for="commish-edit-select">Price Title</label>
-        <select class="input" name="priceid" id="commish-edit-select">
-          <option value="">Select a Price:</option>
-          $for i in query['price']:
-            $for j in query['class']:
-              $if(i['classid'] == j['classid']):
-                <option value="${i['priceid']}">${j['title']} &#8250; ${i['title']}</option>
-                $break
-        </select>
-
-        <label for="commish-edit-title">Rename To</label>
-        <input type="text" class="input" name="title" id="commish-edit-title" placeholder="ex: 'Full Color', 'Basic Pose'" />
-
-        <label for="commish-edit-min-amount">Minimum Amount</label>
-        <input type="number" step="any" class="input" name="min_amount" id="commish-edit-min-amount" />
-
-        <label for="commish-edit-max-amount">Maximum Amount (Optional)</label>
-        <input type="number" step="any" class="input last-input" name="max_amount" id="commish-edit-max-amount" />
-
-        <p><input type="checkbox" name="edit_settings" /> <strong>Edit Currency and Settings</strong></p>
-
-
-        <label for="commish-edit-currency">Currency</label>
-        <select class="input" name="currency" id="commish-edit-currency">
-        $for char, info in currencies.iteritems():
-          <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
-        </select>
-
-        <label for="commish-edit-settings">Settings</label>
-        <select class="input last-input" name="settings" id="commish-edit-settings">
-          <option value="" selected="selected">This price is a base cost</option>
-          <option value="a">This price is an additional cost</option>
-        </select>
-
-        <button type="submit" class="button positive" style="float: right;">Edit Price</button>
-      </form>
-
-
-      <h3>Remove Price</h3>
-      <form name="controlremovecommishprice" action="/control/removecommishprice" method="post" class="clear">
-        $:{CSRF()}
-        <label for="commish-removeprice">Price Title</label>
-        <select class="input last-input" name="priceid" id="commish-removeprice">
-          <option value="">Select a Price:</option>
-          $for i in query['price']:
-            $for j in query['class']:
-              $if(i['classid'] == j['classid']):
-                <option value="${i['priceid']}">${j['title']} &#8250; ${i['title']}</option>
-                $break
-        </select>
-
-        <button type="submit" class="button last-input negative" style="float: right;">Remove Price</button>
-      </form>
-
-  </div><!-- /prices -->
-
-  <div class="column info">
-    <h3>Additional Information</h3>
-
-    <form name="controleditcommishtext" action="/control/editcommishtext" method="post" class="clear">
-      $:{CSRF()}
-
-      <label for="commish-info">Description</label>
-      <textarea class="markdown input last-input expanding" name="content" rows="8" id="commish-info">${query['content'] if query['content'] else ''}</textarea>
-      <br />
-
-      <button type="submit" class="button positive" style="float: right;">Save Description</button>
-    </form>
-
-    <div class="di-tags">
-      <h3>Preferred Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-      <p>
-        Use these tags to indicate subject matter you prefer to create, making it easier for
-        commissioners to find you.
-      </p>
-
-      <div class="tags open clear">
-        $if query['tags']:
-          $for tag in query['tags']:
-            <a href="/marketplace?q=${tag}">${tag}</a>
-        $else:
-          <p class="color-lighter">You have not defined any preferred tags.</p>
       </div>
+    </div>
+    <hr />
 
-      <h3 class="edit">Edit Tags</h3>
-      $:{RENDER("common/detail_tag_form.html", [query['userid'], "user", query['tags']])}
+    <div>
+      <div class="commish-row">
+        <div class="half">
+          <h3>Edit/Remove a Class</h3>
+          <p>Rename, reclassify, or remove a class</p>
+          <form name="controleditcommishclass" action="/control/editcommishclass" method="post" class="clear">
+            $:{CSRF()}
+            <label for="commishprices-editclass">Class Title</label>
+            <select id="commishprices-editclass" class="input" name="classid">
+              <option value="">Select class:</option>
+              $for i in query['class']:
+              <option value="${i['classid']}">${i['title']}</option>
+            </select>
 
-    </div><!-- /di-tags -->
-    <div class="di-tags">
-      <h3>Opt-Out Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-      <p>
-        You will not appear in results for commission searches containing these tags.
-      </p>
+            <label for="commishprices-renameclass">Rename To</label>
+            <input type="text" id="commishprices-renameclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
 
-      <div class="tags open clear">
-        $if query['opt_out']:
-          $for tag in query['opt_out']:
-            <a class="artist" href="/marketplace?q=${tag}">${tag}</a>
-        $else:
-          <p class="color-lighter">You have not defined any opt-out tags.</p>
+            <p><input type="checkbox" name="edit_settings" /> <strong>Change Commission Type</strong></p>
+            <label for="commishprices-addclass-preset">Class Presets</label>
+            <select class="input last-input" name="titlepreset" id="commishprices-addclass-preset">
+              <option value="" selected>Any/Other</option>
+              $for group_name, group_options in presets:
+              <optgroup label="${group_name}">
+                $for c in group_options:
+                <option value="${c}">${c}</option>
+              </optgroup>
+            </select>
+            <h4 class="or color-lighter"><i>&mdash; Or &mdash;</i></h4>
+            <label for="commishprices-addclass">Custom Class</label>
+            <input type="text" id="commishprices-addclass" class="input last-input" name="title"/>
+            <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Class</button>
+            <button type="submit" class="button negative" style="float: right;">Remove Class</button>
+          </form>
+        </div>
+
+        <div class="half">
+          <h3>Edit/Remove a Price</h3>
+          <p>Rename, revalue, or delete a price</p>
+          <form name="controleditcommishprice" action="/control/editcommishprice" method="post" class="clear">
+            $:{CSRF()}
+            <label for="commish-edit-select">Price Title</label>
+            <select class="input" name="priceid" id="commish-edit-select">
+              <option value="">Select a Price:</option>
+              $for i in query['price']:
+                $for j in query['class']:
+                  $if(i['classid'] == j['classid']):
+                    <option value="${i['priceid']}">${j['title']} &#8250; ${i['title']}</option>
+                    $break
+            </select>
+
+            <label for="commish-edit-title">Rename To</label>
+            <input type="text" class="input last-input" name="title" id="commish-edit-title" placeholder="ex: 'Full Color', 'Basic Pose'" />
+
+            <p><input type="checkbox" name="edit_settings" /> <strong>Edit Currency and Type:</strong></p>
+            <label for="commish-edit-min-amount">Minimum Amount</label>
+            <input type="number" step="any" class="input" name="min_amount" id="commish-edit-min-amount" />
+
+            <label for="commish-edit-max-amount">Maximum Amount (Optional)</label>
+            <input type="number" step="any" class="input last-input" name="max_amount" id="commish-edit-max-amount" />
+
+            <label for="commish-edit-currency">Currency</label>
+            <select class="input" name="currency" id="commish-edit-currency">
+            $for char, info in currencies.iteritems():
+              <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
+            </select>
+
+            <label for="commish-settings">Cost type</label>
+            <select class="input last-input" name="settings" id="commish-settings">
+              <option value="" selected="selected">This price is a base cost</option>
+              <option value="a">This price is an additional cost</option>
+            </select>
+
+            <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Price</button>
+            <button type="submit" class="button negative" style="float: right;">Remove Price</button>
+        </div>
       </div>
-
-      <h3 class="edit">Edit Tags</h3>
-      $:{RENDER("common/detail_tag_form.html", [query['userid'], "optout", query['opt_out']])}
-    </div><!-- /di-tags2 -->
-  </div><!-- /info -->
-
+    </div>
 </div><!-- /content -->

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -54,7 +54,26 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
           <h3 class="edit">Edit Tags</h3>
           $:{RENDER("common/detail_tag_form.html", [query['userid'], "optout", query['opt_out']])}
         </div><!-- /di-tags2 -->
-      </div>
+        <div id="user-commissions" class="clear on-side">
+          <h3>Preview</h3>
+          $for i in query['class']:
+            <h4 class="color-c">${i['title']}</h4>
+            <dl class="leaders">
+            $for j in query['price']:
+              $if(j['classid'] == i['classid'] and 'a' not in j['settings']):
+                <dt>${j['title']}</dt>
+                <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
+                $if(j['amount_max']):
+                  <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
+            $for j in query['price']:
+              $if(j['classid'] == i['classid'] and 'a' in j['settings']):
+                <dt><i>add &#160;</i>${j['title']}</dt>
+                <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
+                $if(j['amount_max']):
+                  <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
+            </dl>
+        </div><!-- /user-commissions -->
+      </div><!-- /commish-tags -->
     </div>
   </div>
   <hr />
@@ -66,11 +85,9 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
       <div class="commish-row">
         $:{CSRF()}
         <div class="half">
-          <label for="commishprices-addclass">Class Name</label>
-          <input type="text" id="commishprices-addclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
           <label for="commishprices-addclass-preset">Class Presets</label>
           <select class="input last-input" name="titlepreset" id="commishprices-addclass-preset">
-            <option value="" selected>Any/Other</option>
+            <option value="" selected>Other</option>
             $for group_name, group_options in presets:
               <optgroup label="${group_name}">
                 $for c in group_options:
@@ -86,14 +103,14 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
           <input type="text" class="input" name="title" id="commishprices-addclass-price" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
 
           <label for="commish-min-amount">Minimum Amount</label>
-          <input type="text" class="input" name="min_amount" id="commish-min-amount" required="required" />
+          <input type="number" step="any" class="input" name="min_amount" id="commish-min-amount" required="required" />
 
           <label for="commish-max-amount">Maximum Amount (Optional)</label>
-          <input type="text" class="input" name="max_amount" id="commish-max-amount" />
+          <input type="number" step="any" class="input" name="max_amount" id="commish-max-amount" />
 
 
           <label for="commish-currency">Currency</label>
-          <select class="last-input" name="currency" id="commish-currency">
+          <select class="input last-input" name="currency" id="commish-currency">
             <option value="" selected="selected">United States Dollar</option>
             <option value="e">European Union Euro</option>
             <option value="p">British Pound Sterling</option>
@@ -108,7 +125,7 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
     </form>
   </div>
   <hr />
-  $if(query['class']) or True:
+  $if(query['class']):
     <div>
       <h3>Add a Price to a Class</h3>
       <p>Add a new base or add-on cost to a commission class</p>
@@ -138,16 +155,19 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
               <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
             </select>
 
-            <label for="commish-settings">Cost type</label>
-            <select class="input last-input" name="settings" id="commish-settings">
-              <option value="" selected="selected">This price is a base cost</option>
-              <option value="a">This price is an additional cost</option>
-            </select>
+              <label>Cost type</label>
+              <label class="input-checkbox">
+                <input type="radio" name="settings" value="" checked="checked">This price is a base cost
+              </label>
+              <label class="input-checkbox">
+                <input type="radio" name="settings" value="a">This price is an additional cost
+              </label>
           <button type="submit" class="button positive" style="float: right;">Create Price</button>
+
         </div>
       </form>
-      </div>
     </div>
+
     <hr />
 
     <div>
@@ -166,20 +186,6 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
 
             <label for="commishprices-renameclass">Rename To</label>
             <input type="text" id="commishprices-renameclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
-
-            <p><input type="checkbox" name="edit_settings" /> <strong>Change Commission Type</strong></p>
-            <label for="commishprices-addclass-preset">Class Presets</label>
-            <select class="input last-input" name="titlepreset" id="commishprices-addclass-preset">
-              <option value="" selected>Any/Other</option>
-              $for group_name, group_options in presets:
-              <optgroup label="${group_name}">
-                $for c in group_options:
-                <option value="${c}">${c}</option>
-              </optgroup>
-            </select>
-            <h4 class="or color-lighter"><i>&mdash; Or &mdash;</i></h4>
-            <label for="commishprices-addclass">Custom Class</label>
-            <input type="text" id="commishprices-addclass" class="input last-input" name="title"/>
             <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Class</button>
             <button type="submit" class="button negative" style="float: right;">Remove Class</button>
           </form>
@@ -188,42 +194,52 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
         <div class="half">
           <h3>Edit/Remove a Price</h3>
           <p>Rename, revalue, or delete a price</p>
-          <form name="controleditcommishprice" action="/control/editcommishprice" method="post" class="clear">
-            $:{CSRF()}
-            <label for="commish-edit-select">Price Title</label>
-            <select class="input" name="priceid" id="commish-edit-select">
-              <option value="">Select a Price:</option>
-              $for i in query['price']:
-                $for j in query['class']:
-                  $if(i['classid'] == j['classid']):
-                    <option value="${i['priceid']}">${j['title']} &#8250; ${i['title']}</option>
-                    $break
-            </select>
+          <label for="commish-edit-select">Price Title</label>
+          <select class="input" name="priceid" id="commish-edit-select">
+            <option value="">Select a Price:</option>
+            $for i in query['price']:
+              $for j in query['class']:
+                $if(i['classid'] == j['classid']):
+                  <option value="${i['priceid']}">${j['title']} &#8250; ${i['title']}</option>
+                  $break
+          </select>
 
-            <label for="commish-edit-title">Rename To</label>
-            <input type="text" class="input last-input" name="title" id="commish-edit-title" placeholder="ex: 'Full Color', 'Basic Pose'" />
+          $for price in query['price']:
+            <form name="controleditcommishprice" action="/control/editcommishprice" method="post"
+                  class="clear select-priceid" data-priceid="${price['priceid']}" style="display:none;">
+              $:{CSRF()}
 
-            <p><input type="checkbox" name="edit_settings" /> <strong>Edit Currency and Type:</strong></p>
-            <label for="commish-edit-min-amount">Minimum Amount</label>
-            <input type="number" step="any" class="input" name="min_amount" id="commish-edit-min-amount" />
+              <label for="commish-edit-title">Rename To</label>
+              <input type="text" class="input" name="title" id="commish-edit-title"
+                     placeholder="ex: 'Full Color', 'Basic Pose'" value="${price['title']}"/>
 
-            <label for="commish-edit-max-amount">Maximum Amount (Optional)</label>
-            <input type="number" step="any" class="input last-input" name="max_amount" id="commish-edit-max-amount" />
+              <label for="commish-edit-min-amount">Minimum Amount</label>
+              <input type="number" step="any" class="input" name="min_amount" id="commish-edit-min-amount"
+                     value="${PRICE(price['amount_min'])}"/>
 
-            <label for="commish-edit-currency">Currency</label>
-            <select class="input" name="currency" id="commish-edit-currency">
-            $for char, info in currencies.iteritems():
-              <option value="${char}" $:{'selected="selected"' if not char else ""}>${info.name}</option>
-            </select>
+              <label for="commish-edit-max-amount">Maximum Amount (Optional)</label>
+              <input type="number" step="any" class="input" name="max_amount" id="commish-edit-max-amount"
+                     value="${PRICE(price['amount_max']) if price['amount_max'] else ''}"/>
 
-            <label for="commish-settings">Cost type</label>
-            <select class="input last-input" name="settings" id="commish-settings">
-              <option value="" selected="selected">This price is a base cost</option>
-              <option value="a">This price is an additional cost</option>
-            </select>
+              <label for="commish-edit-currency">Currency</label>
+              <select class="input" name="currency" id="commish-edit-currency">
+              $for char, info in currencies.iteritems():
+                <option value="${char}" $:{'selected="selected"' if char in price['settings'] else ""}>${info.name}</option>
+              </select>
 
-            <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Price</button>
-            <button type="submit" class="button negative" style="float: right;">Remove Price</button>
+              <label>Cost type</label>
+              <label class="input-checkbox">
+                <input type="radio" name="settings" value=""
+                       $:{'checked="checked"' if 'a' not in price['settings'] else ""}>This price is a base cost
+              </label>
+              <label class="input-checkbox">
+                <input type="radio" name="settings" value="a"
+                       $:{'checked="checked"' if 'a' in price['settings'] else ""}>This price is an additional cost
+              </label>
+
+              <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Price</button>
+              <button type="submit" class="button negative" style="float: right;">Remove Price</button>
+            </form>
         </div>
       </div>
     </div>

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -202,7 +202,7 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
         <div class="half">
           <h3>Edit/Remove a Class</h3>
           <p>Rename, reclassify, or remove a class</p>
-          <form name="controleditcommishclass" action="/control/editcommishclass" method="post" class="clear">
+          <form name="controleditcommishclass" method="post" class="clear">
             $:{CSRF()}
             <label for="commishprices-editclass">Class Title</label>
             <select id="commishprices-editclass" class="input" name="classid">
@@ -213,8 +213,8 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
 
             <label for="commishprices-renameclass">Rename To</label>
             <input type="text" id="commishprices-renameclass" class="input last-input" name="title" required="required" placeholder="ex: 'Sketches', 'Badges'" />
-            <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Class</button>
-            <button type="submit" class="button negative" style="float: right;">Remove Class</button>
+            <button type="submit" formaction="/control/editcommishclass" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Class</button>
+            <button type="submit" formaction="/control/removecommishclass" class="button negative" formnovalidate="formnovalidate" style="float: right;">Remove Class</button>
           </form>
         </div>
 

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -232,10 +232,10 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
           </select>
 
           $for price in query['price']:
-            <form name="controleditcommishprice" action="/control/editcommishprice" method="post"
-                  class="clear select-priceid" data-priceid="${price['priceid']}" style="display:none;">
+            <form name="controleditcommishprice" method="post" class="clear select-priceid"
+                  data-priceid="${price['priceid']}" style="display:none;">
               $:{CSRF()}
-
+              <input type="hidden" name="priceid" value="${price['priceid']}">
               <label for="commish-edit-title">Rename To</label>
               <input type="text" class="input" name="title" id="commish-edit-title"
                      placeholder="ex: 'Full Color', 'Basic Pose'" value="${price['title']}"/>
@@ -264,8 +264,8 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
                        $:{'checked="checked"' if 'a' in price['settings'] else ""}>This price is an additional cost
               </label>
 
-              <button type="submit" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Price</button>
-              <button type="submit" class="button negative" style="float: right;">Remove Price</button>
+              <button type="submit" formaction="/control/editcommishprice" class="button last-input positive" style="float: right; margin-left: 5px;">Edit Price</button>
+              <button type="submit" formaction="/control/removecommishprice" class="button negative" style="float: right;">Remove Price</button>
             </form>
         </div>
       </div>

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -138,13 +138,8 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
 
           <label for="commish-currency">Currency</label>
           <select class="input last-input" name="currency" id="commish-currency">
-            <option value="" selected="selected">United States Dollar</option>
-            <option value="e">European Union Euro</option>
-            <option value="p">British Pound Sterling</option>
-            <option value="y">Japanese Yen</option>
-            <option value="c">Canadian Dollar</option>
-            <option value="m">Mexican Peso</option>
-            <option value="u">Australian Dollar</option>
+            $for char, info in currencies.iteritems():
+              <option value="${char}">${info.name}</option>
           </select>
           <button type="submit" class="button positive" style="float: right;">Create Class</button>
         </div>

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -127,7 +127,7 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
         </div>
         <div class="half">
           <label for="commishprices-addclass-price">Base Price Title</label>
-          <input type="text" class="input" name="title" id="commishprices-addclass-price" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
+          <input type="text" class="input" name="price_title" id="commishprices-addclass-price" required="required" placeholder="ex: 'Full Color', 'Basic Pose'" />
 
           <label for="commish-min-amount">Minimum Amount</label>
           <input type="number" step="any" class="input" name="min_amount" id="commish-min-amount" required="required" />

--- a/templates/control/edit_commissionprices.html
+++ b/templates/control/edit_commissionprices.html
@@ -1,20 +1,47 @@
-$def with (query, currencies, presets)
-$:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
+$def with (query, currencies, presets, profile)
+$code:
+  def _SELECTED(x, y):
+    return ' selected="selected"' if profile['settings'][x] == y else ''
 
+$:{RENDER("common/stage_title.html", ["Edit Commission Prices", "Settings"])}
 <div id="commishprices-content" class="content form clear">
   <div>
     <h3>My General Commission Info</h3>
     <p>Information about commissioning you and preferences for commission content</p>
     <div class="commish-row">
       <div class="info">
-        <form name="controleditcommishtext" action="/control/editcommishtext" method="post" class="clear">
+        <form name="controleditcommishtext" action="/control/editcommishinfo" method="post" class="clear">
           $:{CSRF()}
+          <!-- Copied from edit_profile.html. TODO(hyena): Only put this in one place, probably here. -->
+          <label for="editprofile-setcommish">Commissions</label>
+          <select id="editprofile-setcommish" class="input" name="set_commish">
+            <option value="o"${_SELECTED(0, 'o')}>I am currently accepting commissions</option>
+            <option value="s"${_SELECTED(0, 's')}>I may sometimes accept commissions</option>
+            <option value="f"${_SELECTED(0, 'f')}>My commission queue is currently filled</option>
+            <option value="c"${_SELECTED(0, 'c')}>I am not accepting commissions right now</option>
+            <option value="e"${_SELECTED(0, 'e')}>This is not applicable to me</option>
+          </select>
 
-          <label for="commish-info">Description</label>
+          <label for="editprofile-settrade">Trades</label>
+          <select id="editprofile-settrade" class="input" name="set_trade">
+            <option value="o"${_SELECTED(1, 'o')}>I am currently accepting trades</option>
+            <option value="s"${_SELECTED(1, 's')}>I may sometimes accept trades</option>
+            <option value="c"${_SELECTED(1, 'c')}>I am not accepting trades right now</option>
+            <option value="e"${_SELECTED(1, 'e')}>This is not applicable to me</option>
+          </select>
+
+          <label for="editprofile-setrequest">Requests</label>
+          <select id="editprofile-setrequest" class="input" name="set_request">
+            <option value="o"${_SELECTED(2, 'o')}>I am currently accepting requests</option>
+            <option value="s"${_SELECTED(2, 's')}>I may sometimes accept requests</option>
+            <option value="c"${_SELECTED(2, 'c')}>I am not accepting requests right now</option>
+            <option value="e"${_SELECTED(2, 'e')}>This is not applicable to me</option>
+          </select>
+          <label for="commish-info">Your Commission Info</label>
           <textarea class="markdown input last-input expanding" name="content" rows="8" id="commish-info">${query['content'] if query['content'] else ''}</textarea>
           <br />
 
-          <button type="submit" class="button positive" style="float: right;">Save Description</button>
+          <button type="submit" class="button positive" style="float: right;">Save Info</button>
         </form>
       </div>
       <div class="commish-tags">

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -306,6 +306,9 @@ def select_commissionable(userid, q, commishclass, min_price, max_price, currenc
 
 
 def create_commission_class(userid, title):
+    """
+    Creates a new commission class and returns its id.
+    """
     if not title:
         raise WeasylError("titleInvalid")
 
@@ -313,6 +316,7 @@ def create_commission_class(userid, title):
 
     try:
         d.execute("INSERT INTO commishclass VALUES (%i, %i, '%s')", [classid if classid else 1, userid, title])
+        return classid
     except PostgresError:
         raise WeasylError("commishclassExists")
 

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -417,6 +417,7 @@ def edit_content(userid, content):
 
 def remove_class(userid, classid):
     d.execute("DELETE FROM commishclass WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
+    d.execute("DELETE FROM commishprice WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
 
 
 def remove_price(userid, priceid):

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -188,10 +188,10 @@ def select_commissionable(userid, q, commishclass, min_price, max_price, currenc
     and have defined at least one commission class.
 
     This query sorts primarily by how many matching tags in the "content" field match
-    a user's artist tags. Secondarily, it sorts by the user's most recent upload time
+    an artist's preferred tags. Secondarily, it sorts by the artist's most recent upload time
     (of any submission that is not hidden or friends-only).
-    This way users who are more active on the site will recieve a higher search ranking.
-    Ignored users and banned/suspended users will not appear in search results.
+    This way artists who are more active on the site will receive a higher search ranking.
+    Ignored artists and banned/suspended artists will not appear in search results.
 
     Commission prices are converted to $currency before being compared against min_price and max_price.
     This way, a search with a min price of "1000 JPY" can still return a result for a commission

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -364,7 +364,7 @@ def edit_class(userid, commishclass):
         raise WeasylError("titleExists")
 
 
-def edit_price(userid, price, currency="", settings="", edit_prices=False, edit_settings=False):
+def edit_price(userid, price, currency="", settings="", edit_prices=False):
     currency = "".join(i for i in currency if i in CURRENCY_CHARMAP)
     settings = "".join(i for i in settings if i in "a")
 
@@ -396,9 +396,8 @@ def edit_price(userid, price, currency="", settings="", edit_prices=False, edit_
             statement.append("%s amount_max = %%i" % ("," if argv else ""))
             argv.append(price.amount_max)
 
-    if edit_settings:
-        statement.append("%s settings = '%%s'" % ("," if argv else ""))
-        argv.append("%s%s" % (currency, settings))
+    statement.append("%s settings = '%%s'" % ("," if argv else ""))
+    argv.append("%s%s" % (currency, settings))
 
     if not argv:
         return
@@ -416,9 +415,15 @@ def edit_content(userid, content):
 
 
 def remove_class(userid, classid):
+    if not d.execute("SELECT EXISTS (SELECT 0 FROM commishclass WHERE (classid, userid) = (%i, %i))",
+                     [d.get_int(classid), userid], ["bool"]):
+        raise WeasylError("classidInvalid")
     d.execute("DELETE FROM commishclass WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
     d.execute("DELETE FROM commishprice WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
 
 
 def remove_price(userid, priceid):
+    if not d.execute("SELECT EXISTS (SELECT 0 FROM commishprice WHERE (priceid, userid) = (%i, %i))",
+                     [d.get_int(priceid), userid], ["bool"]):
+        raise WeasylError("priceidInvalid")
     d.execute("DELETE FROM commishprice WHERE (priceid, userid) = (%i, %i)", [d.get_int(priceid), userid])

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -160,10 +160,11 @@ routes = (
           {'POST': settings.control_uploadavatar_}),
     Route("/control/editprofile", "control_editprofile",
           {'GET': settings.control_editprofile_get_, 'POST': settings.control_editprofile_put_}),
+
     Route("/control/editcommissionprices", "control_editcommissionprices",
           settings.control_editcommissionprices_),
-    Route("/control/editcommishtext", "control_editcommishtext",
-          {'POST': settings.control_editcommishtext_}),
+    Route("/control/editcommishinfo", "control_editcommishinfo",
+          {'POST': settings.control_editcommishinfo_}),
     Route("/control/createcommishclass", "control_createcommishclass",
           {'POST': settings.control_createcommishclass_}),
     Route("/control/editcommishclass", "control_editcommishclass",
@@ -176,6 +177,7 @@ routes = (
           {'POST': settings.control_editcommishprice_}),
     Route("/control/removecommishprice", "control_removecommishprice",
           {'POST': settings.control_removecommishprice_}),
+
     Route("/control/editemailpassword", "control_editemailpassword", {
         'GET': settings.control_editemailpassword_get_,
         'POST': settings.control_editemailpassword_post_

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -130,7 +130,7 @@ def control_createcommishclass_(request):
 @login_required
 @token_checked
 def control_editcommishclass_(request):
-    form = request.web_input(classid="")
+    form = request.web_input(classid="", title="")
 
     commishclass = orm.CommishClass()
     commishclass.title = form.title.strip()

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -89,14 +89,19 @@ def control_editcommissionprices_(request):
         commishinfo.select_list(request.userid),
         commishinfo.CURRENCY_CHARMAP,
         commishinfo.PRESET_COMMISSION_CLASSES,
+        profile.select_profile(request.userid)
     ]))
 
 
 @login_required
 @token_checked
-def control_editcommishtext_(request):
-    form = request.web_input(content="")
+def control_editcommishinfo_(request):
+    form = request.web_input(content="", set_commish="", set_trade="", set_request="")
+    set_trade = profile.get_exchange_setting(profile.EXCHANGE_TYPE_TRADE, form.set_trade)
+    set_request = profile.get_exchange_setting(profile.EXCHANGE_TYPE_REQUEST, form.set_request)
+    set_commission = profile.get_exchange_setting(profile.EXCHANGE_TYPE_COMMISSION, form.set_commish)
 
+    profile.edit_profile_settings(request.userid, set_trade, set_request, set_commission)
     commishinfo.edit_content(request.userid, form.content)
     raise HTTPSeeOther(location="/control/editcommissionprices")
 

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -166,7 +166,7 @@ def control_createcommishprice_(request):
 @login_required
 @token_checked
 def control_editcommishprice_(request):
-    form = request.web_input(priceid="", title="", min_amount="", max_amount="", edit_settings="", currency="", settings="")
+    form = request.web_input(priceid="", title="", min_amount="", max_amount="", currency="", settings="")
 
     price = orm.CommishPrice()
     price.title = form.title.strip()
@@ -175,14 +175,14 @@ def control_editcommishprice_(request):
     price.amount_max = commishinfo.parse_currency(form.max_amount)
     edit_prices = bool(price.amount_min or price.amount_max)
     commishinfo.edit_price(request.userid, price, currency=form.currency,
-                           settings=form.settings, edit_prices=edit_prices, edit_settings=form.edit_settings)
+                           settings=form.settings, edit_prices=edit_prices)
     raise HTTPSeeOther(location="/control/editcommissionprices")
 
 
 @login_required
 @token_checked
 def control_removecommishprice_(request):
-    form = request.web_input(classid="")
+    form = request.web_input(priceid="")
 
     commishinfo.remove_price(request.userid, form.priceid)
     raise HTTPSeeOther(location="/control/editcommissionprices")

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -82,6 +82,18 @@ def get_exchange_setting(exchange_type, code):
     return EXCHANGE_SETTING_CODE_MAP[code]
 
 
+def exchange_settings_from_settings_string(settings_string):
+    """
+    Given a (terrible and brittle) exchange settings string from a user profile,
+    returns a dict of their exchange settings.
+    """
+    return {
+        EXCHANGE_TYPE_COMMISSION: EXCHANGE_SETTING_CODE_MAP[settings_string[0]],
+        EXCHANGE_TYPE_TRADE: EXCHANGE_SETTING_CODE_MAP[settings_string[1]],
+        EXCHANGE_TYPE_REQUEST: EXCHANGE_SETTING_CODE_MAP[settings_string[2]],
+    }
+
+
 def resolve(userid, otherid, othername, myself=True):
     """
     Attempts to determine the userid of a specified user; resolves using otherid,
@@ -378,6 +390,19 @@ def select_avatars(userids):
     results = [dict(row) for row in results]
     media.populate_with_user_media(results)
     return {d['userid']: d for d in results}
+
+
+def edit_profile_settings(userid,
+                          set_trade=EXCHANGE_SETTING_NOT_ACCEPTING,
+                          set_request=EXCHANGE_SETTING_NOT_ACCEPTING,
+                          set_commission=EXCHANGE_SETTING_NOT_ACCEPTING):
+    settings = "".join([set_commission.code, set_trade.code, set_request.code])
+    d.execute(
+        "UPDATE profile "
+        "SET settings = '%s' "
+        "WHERE userid = %i",
+        [settings, userid])
+    d._get_config.invalidate(userid)
 
 
 def edit_profile(userid, profile,
@@ -775,6 +800,7 @@ def force_resetbirthday(userid, birthday):
     d.get_login_settings.invalidate(userid)
 
 
+# TODO(hyena): Make this class unnecessary and remove it when we fix up settings.
 class ProfileSettings(object):
     """
     This class standardizes access to jsonb profile settings,

--- a/weasyl/test/test_marketplace.py
+++ b/weasyl/test/test_marketplace.py
@@ -122,8 +122,10 @@ def test_commish_search_invalid():
 def create_commish_searchable_user(username, commish_status='o', commishclass='badge',
                                    minprice="10.00", maxprice="15.00", currency='', submittime=arrow.get(1)):
     user = db_utils.create_user(username=username)
-    profile.edit_profile(userid=user, profile=orm.Profile(),
-                         set_commission=profile.get_exchange_setting(profile.EXCHANGE_TYPE_COMMISSION, commish_status))
+    profile.edit_profile_settings(
+        userid=user,
+        set_commission=profile.get_exchange_setting(profile.EXCHANGE_TYPE_COMMISSION, commish_status)
+    )
     commishinfo.create_commission_class(user, commishclass)
     classid = commishinfo.select_list(user)["class"][0]["classid"]
     assert classid

--- a/weasyl/test/test_profile.py
+++ b/weasyl/test/test_profile.py
@@ -83,3 +83,16 @@ class ProfileManageTestCase(unittest.TestCase):
             ('Email', ['mailto:sysop@weasyl.com']),
             ('Twitter', ['Weasyl', 'WeasylDev']),
         ])
+
+    def test_valid_commission_settings(self):
+        user = db_utils.create_user()
+
+        profile.edit_profile_settings(user,
+                                      set_trade=profile.EXCHANGE_SETTING_ACCEPTING,
+                                      set_request=profile.EXCHANGE_SETTING_NOT_ACCEPTING,
+                                      set_commission=profile.EXCHANGE_SETTING_FULL_QUEUE)
+        test_user_profile = profile.select_profile(user)
+        exchange_settings = profile.exchange_settings_from_settings_string(test_user_profile['settings'])
+        self.assertEqual(exchange_settings[profile.EXCHANGE_TYPE_TRADE], profile.EXCHANGE_SETTING_ACCEPTING)
+        self.assertEqual(exchange_settings[profile.EXCHANGE_TYPE_REQUEST], profile.EXCHANGE_SETTING_NOT_ACCEPTING)
+        self.assertEqual(exchange_settings[profile.EXCHANGE_TYPE_COMMISSION], profile.EXCHANGE_SETTING_FULL_QUEUE)


### PR DESCRIPTION
~*PRESENTLY NONFUNCTIONAL. DO NOT MERGE*~ Should be functional now.
Opening the PR anyway for feedback. Feel free to deracinate this, critique, etc. Frontend is definitely not my forte.

 - Re-organizes control panel into task-oriented rows.
 - Presently non-functional and should not be merged.
 - Introduces flexbox for layout.

Some notes:
 - Layout is not that great still. Feels kind of vast and barren
 - The checkboxes are rather awkward for a 2017 UI. How hard would it be to write javascript that dynamically fill in price information, commission class type, etc. when we select from the form?
 - I'm not married to the horizontal rules.